### PR TITLE
Fix translated host, allow ipv6

### DIFF
--- a/aiosnmp/connection.py
+++ b/aiosnmp/connection.py
@@ -3,7 +3,7 @@ __all__ = ("SnmpConnection",)
 import asyncio
 from typing import Optional, cast
 
-from .protocols import SnmpProtocol
+from .protocols import Address, SnmpProtocol
 
 DEFAULT_TIMEOUT = 1
 DEFAULT_RETRIES = 6
@@ -13,6 +13,7 @@ class SnmpConnection:
     __slots__ = (
         "_protocol",
         "_transport",
+        "_peername",
         "host",
         "port",
         "loop",
@@ -33,6 +34,7 @@ class SnmpConnection:
         self.loop: asyncio.AbstractEventLoop = asyncio.get_event_loop()
         self._protocol: Optional[SnmpProtocol] = None
         self._transport: Optional[asyncio.DatagramTransport] = None
+        self._peername: Optional[Address] = None
         self.timeout: float = timeout
         self.retries: int = retries
 
@@ -47,6 +49,9 @@ class SnmpConnection:
 
         self._protocol = cast(SnmpProtocol, protocol)
         self._transport = cast(asyncio.DatagramTransport, transport)
+        self._peername = self._transport.get_extra_info(
+            "peername", default=(self.host, self.port)
+        )
 
     def close(self) -> None:
         if self._transport is not None and not self._transport.is_closing():
@@ -54,3 +59,4 @@ class SnmpConnection:
 
         self._protocol = None
         self._transport = None
+        self._peername = None

--- a/aiosnmp/protocols.py
+++ b/aiosnmp/protocols.py
@@ -45,6 +45,8 @@ _ERROR_STATUS_TO_EXCEPTION = {
     18: SnmpErrorInconsistentName,
 }
 
+Address = Union[Tuple[str, int], Tuple[str, int, int, int]]
+
 
 class SnmpTrapProtocol(asyncio.DatagramProtocol):
     __slots__ = ("loop", "transport", "communities", "handler")
@@ -57,10 +59,8 @@ class SnmpTrapProtocol(asyncio.DatagramProtocol):
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
 
-    def datagram_received(
-        self, data: Union[bytes, Text], addr: Tuple[str, int]
-    ) -> None:
-        host, port = addr
+    def datagram_received(self, data: Union[bytes, Text], addr: Address) -> None:
+        host, port = addr[:2]
 
         if isinstance(data, Text):
             return
@@ -85,10 +85,8 @@ class SnmpProtocol(asyncio.DatagramProtocol):
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         self.transport = cast(asyncio.DatagramTransport, transport)
 
-    def datagram_received(
-        self, data: Union[bytes, Text], addr: Tuple[str, int]
-    ) -> None:
-        host, port = addr
+    def datagram_received(self, data: Union[bytes, Text], addr: Address) -> None:
+        host, port = addr[:2]
 
         if isinstance(data, Text):
             raise RuntimeError("data should be bytes.")

--- a/aiosnmp/snmp.py
+++ b/aiosnmp/snmp.py
@@ -51,7 +51,8 @@ class Snmp(SnmpConnection):
         if self._protocol is None:
             await self._connect()
         assert self._protocol
-        return await self._protocol._send(message, self.host, self.port)
+        assert self._peername
+        return await self._protocol._send(message, *self._peername[:2])
 
     async def get(self, oids: Union[str, List[str]]) -> List[SnmpVarbind]:
         if isinstance(oids, str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,6 @@ def pytest_configure(config):
 
 def pytest_generate_tests(metafunc):
     if "host" in metafunc.fixturenames:
-        metafunc.parametrize("host", ["127.0.0.1"])
+        metafunc.parametrize("host", ["127.0.0.1", "localhost", "::1"])
     if "port" in metafunc.fixturenames:
         metafunc.parametrize("port", [int(os.environ["KOSHH/AIOSNMP_161_UDP"])])

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -9,6 +9,8 @@ async def test_connection_close(host: str, port: int) -> None:
     await snmp.get(".1.3.6.1.2.1.1.6.0")
     assert snmp._transport
     assert snmp._protocol
+    assert snmp._peername
     snmp.close()
     assert snmp._transport is None
     assert snmp._protocol is None
+    assert snmp._peername is None


### PR DESCRIPTION
These changes address the use of different sockets, and an issue with translated hostnames.
Translated hostnames and `Counter64`/`Uinteger32` to `int` were needed, and thus tested and used.

The other (ipv6, unix socket) less so, so feel free to ask me to drop those changes if they are out of scope.
